### PR TITLE
Add the move_to and capture logic to the piece model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.44.1)
+    rubocop (0.45.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -4,6 +4,7 @@ class GamesController < ApplicationController
   end
 
   def show
+    #@available_game = Game.find(params[:id])
     @available_game = Game.new
   end
 
@@ -47,6 +48,6 @@ class GamesController < ApplicationController
 
     private
   def game_params
-    params.require(:game).permit(:user_id, :user2_id)
+    params.require(:game).permit(:user_id, :user2_id, :name, :white_player_id, :black_player_id)
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -3,6 +3,7 @@ class Piece < ActiveRecord::Base
   belongs_to :game
   belongs_to :player
   belongs_to :board
+  belongs_to :user
 
   def self.types
     %w(Pawn Rook Knight Bishop Queen King)
@@ -63,4 +64,34 @@ class Piece < ActiveRecord::Base
     end
     obstruction
   end
+
+
+# check if the position is filled
+  def pos_filled?(x, y)
+    pieces.active.where(x_coord: x, y_coord: y).any?
+  end
+
+# return the piece at that location
+  def return_piece(x, y)
+    pieces.active.find(x_coord: x, y_coord: y)
+  end
+
+# capture the piece
+  def capture_piece(x, y)
+    self.game.ret_piece(x, y).update(captured: true)
+  end
+
+
+# this method will move a piece to new location and capture if appropriate
+# note that the piece controller is being built by someone else right now, and updating the piece location will require an update method in that controller so it won't function correctly yet
+  def move_to(new_x, new_y)
+    if pos_filled?(new_x, new_y) == true
+      if return_piece(new_x, new_y).user_id != current_user
+         capture_piece(new_x, new_y)
+         update_attributes(x_coord: new_x, y_coord: new_y)
+      end
+    else
+      update_attributes(x_coord: new_x, y_coord: new_y)
+    end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,61 +11,61 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_161_023_204_308) do
+ActiveRecord::Schema.define(version: 20161023204308) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'games', force: true do |t|
-    t.integer  'users_id'
-    t.string   'name'
-    t.integer  'player_id'
-    t.integer  'white_player_id'
-    t.integer  'black_player_id'
-    t.integer  'winner_player_id'
-    t.integer  'status'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "games", force: true do |t|
+    t.integer  "users_id"
+    t.string   "name"
+    t.integer  "player_id"
+    t.integer  "white_player_id"
+    t.integer  "black_player_id"
+    t.integer  "winner_player_id"
+    t.integer  "status"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table 'pieces', force: true do |t|
-    t.integer  'users_id'
-    t.integer  'player_id'
-    t.string   'type'
-    t.boolean  'color'
-    t.integer  'x_coord'
-    t.integer  'y_coord'
-    t.boolean  'captured'
-    t.integer  'game_id'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "pieces", force: true do |t|
+    t.integer  "users_id"
+    t.integer  "player_id"
+    t.string   "type"
+    t.boolean  "color"
+    t.integer  "x_coord"
+    t.integer  "y_coord"
+    t.boolean  "captured"
+    t.integer  "game_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table 'players', force: true do |t|
-    t.integer  'users_id'
-    t.integer  'player_id'
-    t.string   'username'
-    t.string   'email'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
+  create_table "players", force: true do |t|
+    t.integer  "users_id"
+    t.integer  "player_id"
+    t.string   "username"
+    t.string   "email"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table 'users', force: true do |t|
-    t.string   'email',                  default: '', null: false
-    t.string   'encrypted_password',     default: '', null: false
-    t.string   'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.integer  'sign_in_count', default: 0, null: false
-    t.datetime 'current_sign_in_at'
-    t.datetime 'last_sign_in_at'
-    t.inet     'current_sign_in_ip'
-    t.inet     'last_sign_in_ip'
-    t.datetime 'created_at',                          null: false
-    t.datetime 'updated_at',                          null: false
+  create_table "users", force: true do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
-  add_index 'users', ['email'], name: 'index_users_on_email', unique: true, using: :btree
-  add_index 'users', ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true, using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
 end


### PR DESCRIPTION
### What does this PR do?
I added the move_to method to the piece.rb model along with several helper methods. The other methods include:

-  pos_filled? to check if the desired location has a piece in it

- return_piece to get which piece is at that location

- capture_piece to switch the status to captured

The move_to method should check if the position is filled, and if it is filled it will check to see if the piece is from an opposing player. If it is it will capture it and move to that location. If the location is empty, it should just move to that location.

### Where should I start?
piece.rb

### How do I manually test this?
Not able to test at this point because it is dependent on several other features being implemented.

### Additional Comments
Also, there was no pieces controller when I added this functionality, but another person is currently working on it so I didn't add it myself. For the move_to method to work, it will need the update method to be set up correctly in a pieces controller. 



