### PR TITLE
Features/add pieces to board

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem 'simplecov', require: false
   gem 'travis'
   gem 'travis-lint'
+  gem 'pry-rails'
 end
 
 gem 'bootstrap-sass', '~> 3.3.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       sass (>= 3.3.0)
     builder (3.2.2)
     byebug (9.0.6)
+    coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -94,6 +95,7 @@ GEM
       addressable (~> 2.3)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -111,6 +113,12 @@ GEM
       ast (~> 2.2)
     pg (0.19.0)
     powerpack (0.1.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
@@ -177,6 +185,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     spring (1.7.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -233,6 +242,7 @@ DEPENDENCIES
   omniauth
   orm_adapter (= 0.5.0)
   pg
+  pry-rails
   rails (= 4.1.9)
   rspec-rails (~> 3.0)
   rubocop

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -23,7 +23,10 @@
 
   .square {
     flex: 1 0 auto;
-  }
+    font-size: 2.5rem;
+    padding: .5rem 1.25rem;
+    user-select: none;
+    }
 }
 
 .board:hover{

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -2,21 +2,22 @@
 class GamesController < ApplicationController
   # before_action :authenticate_player!
   def index
+    # @games = Game.available
   end
 
   def show
-    # @available_game = Game.find(params[:id])
-    @available_game = Game.new
+    @game = Game.find(params[:id])
+    @pieces = @game.pieces
   end
 
   def new
-    @available_game = Game.new
+    @game = Game.new
   end
 
   def create
-    @available_game = game_params[:user_id]
-    @available_game = Game.create(user2_id: new_user_id, user_id: current_user.id)
-    @available_game.initialize_game_board!
+    @game = game_params[:user_id]
+    @game = Game.create(user2_id: new_user_id, user_id: current_user.id)
+    @game.initialize_game_board!
     redirct_to games_path(@available_game)
   end
 
@@ -24,9 +25,9 @@ class GamesController < ApplicationController
   end
 
   def update
-    @available_game = Game.find(params[:id])
+    @game = Game.find(params[:id])
 
-    if @available_game.update_attributes(params[:game])
+    if @game.update_attributes(params[:game])
       redirect_to games_path, notice: 'New game ready'
     else
       render 'fail to load new game'
@@ -34,8 +35,8 @@ class GamesController < ApplicationController
   end
 
   def destroy
-    @available_game = Game.find(params[:id])
-    @available_game.destroy
+    @game = Game.find(params[:id])
+    @game.destroy
     redirect_to games_path, notice: 'Your game has been cancel'
   end
 

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,2 +1,6 @@
 # frozen_string_literal: true
-class Bishop < Piece; end
+class Bishop < Piece
+  def image
+    color ? '&#9815;' : '&#9821;'
+  end
+end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,2 +1,6 @@
 # frozen_string_literal: true
-class King < Piece; end
+class King < Piece
+  def image
+    color ? '&#9812;' : '&#9818;'
+  end
+end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,2 +1,6 @@
 # frozen_string_literal: true
-class Knight < Piece; end
+class Knight < Piece
+  def image
+    color ? '&#9816;' : '&#9822;'
+  end
+end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,2 +1,6 @@
 # frozen_string_literal: true
-class Pawn < Piece; end
+class Pawn < Piece
+  def image
+    color ? '&#9817;' : '&#9823;'
+  end
+end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,2 +1,6 @@
 # frozen_string_literal: true
-class Queen < Piece; end
+class Queen < Piece
+  def image
+    color ? '&#9813;' : '&#9819;'
+  end
+end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,2 +1,6 @@
 # frozen_string_literal: true
-class Rook < Piece; end
+class Rook < Piece
+  def image
+    color ? '&#9814;' : '&#9820;'
+  end
+end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -3,7 +3,11 @@
     <% 8.times do |row| %>
       <div class="row <%= row.even? ? 'even' : 'odd' %>">
         <% 8.times do |column| %>
-          <div class="square data-x-coord-<%=column%> data-y-coord-<%=row%>"></div>
+          <div class="square data-x-coord-<%=column%> data-y-coord-<%=row%>">
+             <% if @pieces.where(x_coord: column, y_coord: row).present? %>
+                <%= @pieces.where(x_coord: column, y_coord: row).first.image.html_safe %>
+             <% end%>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,85 +1,12 @@
 <section class="board-container">
   <div class="board">
-    <div class="row odd">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
-     <div class="row even">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
-    <div class="row odd">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
-     <div class="row even">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
-    <div class="row odd">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
-     <div class="row even">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
-    <div class="row odd">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
-     <div class="row even">
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-      <div class="square"></div>
-    </div>
+    <% 8.times do |row| %>
+      <div class="row <%= row.even? ? 'even' : 'odd' %>">
+        <% 8.times do |column| %>
+          <div class="square data-x-coord-<%=column%> data-y-coord-<%=row%>"></div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </section>
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -18,7 +18,7 @@
 $(function() {
   function equalHeight(selector){
     var cw = $(selector).width();
-    $(selector).css({'height':cw+'px'});
+    $(selector).css({'height':cw*2+'px'});
   }
 
   equalHeight('.square');


### PR DESCRIPTION
### What does this PR do?
Adds Pieces to boards!

It rebuilds the board to be more programmatic and includes coordinate-based classes. (see in games/show). It uses these coordinates to adds pieces to the board if there is a piece with the same coordinates as the square.

It refactors the `games_controller` to use @game and @pieces.

Rather than using an image for the pieces, I kept it simple and used [Unicode-style chess piece characters](https://en.wikipedia.org/wiki/Chess_symbols_in_Unicode). This can be updated in the future as needed.

I added the `rails-pry` gem. This helps debug instance variables in views by giving you the option to add  `<% binding.pry %>` to a view and have the server pause when it gets there. This way we can use pry normal for views too!

### Where should I start?
Clicking through the commits tells the story of the PR. The new `games/show` page is where the magic is. 

### How do I manually test this?
Well, this is a little odd as this PR relies on the `populate_board` [PR](https://github.com/fire-cakes/pancakes/pull/13), which is not yet merged into master. As such...

1. Pull it down
2. git merge `populate_board`
3. From the command line, create a game
4. After launching a rails server check out that game at [localhost:3000/games/1](//localhost:3000/games/1) Or whatever game you're on

### Additional Comments
This is what the board is looking like now:

<img width="448" alt="screen shot 2016-11-05 at 9 30 10 pm" src="https://cloud.githubusercontent.com/assets/15863213/20035227/83bfe46e-a3a1-11e6-9d0d-79d670ace4ed.png">

### GIF for how this PR makes me feel
![](https://media.giphy.com/media/132xaiItSkgXAs/giphy.gif)
