### PR TITLE
Modified game board to display origin (0,0) as bottom left

### DIFF
--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -35,9 +35,9 @@
 }
 
 .row:nth-child(odd) .square:nth-child(even), .row:nth-child(even) .square:nth-child(odd) {
- background-color: skyblue;
+ background-color: salmon;
 }
 
 .row:nth-child(even) .square:nth-child(even), .row:nth-child(odd) .square:nth-child(odd) {
- background-color: salmon;
+ background-color: skyblue;
 }

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,6 @@
 <section class="board-container">
   <div class="board">
-    <% 8.times do |row| %>
+    <% 7.downto(0) do |row| %>
       <div class="row <%= row.even? ? 'even' : 'odd' %>">
         <% 8.times do |column| %>
           <div class="square data-x-coord-<%=column%> data-y-coord-<%=row%>">
@@ -13,6 +13,8 @@
     <% end %>
   </div>
 </section>
+
+
 
 <script>
 $(function() {


### PR DESCRIPTION
### What does this PR do?
populate_board in the game model was created with the bottom left as the origin coordinate (0,0), but the games/show page displayed the pieces with the top left as the origin coordinate. This PR modifies the games/show page to align with the game model's notation. 

I also switched the black/white squares so that the board starts with a black/red square at the bottom left. 

### Where should I start?
For context, see comment thread on: https://github.com/fire-cakes/pancakes/pull/14



### How do I manually test this?
Same as Pull Request 14:  https://github.com/fire-cakes/pancakes/pull/14
Pull it down
git merge populate_board
From the command line, create a game
  - rails console
  -  Game.create
After launching a rails server check out that game at localhost:3000/games/1 Or whatever game you're on

### Additional Comments
Chess starting positions for reference:
![](https://www.chessvariants.com/d.chess/startup.gif)

