### PR TITLE
Adds turns to games

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -47,6 +47,18 @@ class Game < ActiveRecord::Base
     King.create(game_id: id, x_coord: 4, y_coord: 7, color: false, captured: false)
   end
 
+  def increment_turn
+    self.turn += 1
+  end
+
+  def white_turn?
+    self.turn.odd?
+  end
+
+  def black_turn?
+    self.turn.even?
+  end
+
   def check?(player_color)
     king = pieces.find_by(type: 'King', color: player_color)
     # array of opponent pieces still on the board

--- a/db/migrate/20161120201114_add_turn_to_games.rb
+++ b/db/migrate/20161120201114_add_turn_to_games.rb
@@ -1,0 +1,5 @@
+class AddTurnToGames < ActiveRecord::Migration
+  def change
+    add_column :games, :turn, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161114184117) do
+ActiveRecord::Schema.define(version: 20161120201514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20161114184117) do
     t.integer  "status"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "turn",            default: 1
   end
 
   create_table "pieces", force: true do |t|

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -46,6 +46,28 @@ RSpec.describe Game, type: :model do
     end
   end
 
+  context 'turns' do
+    it 'increments by one' do
+      game = FactoryGirl.create(:game, :with_two_players)
+      expect(game.turn).to be(1)
+      game.increment_turn
+      expect(game.turn).to be(2)
+      game.increment_turn
+      expect(game.turn).to be(3)
+    end
+    it 'odd turns are white' do
+      game = FactoryGirl.create(:game, :with_two_players)
+      expect(game.white_turn?).to be true
+      expect(game.black_turn?).to be false
+    end
+    it 'even turns are black' do
+      game = FactoryGirl.create(:game, :with_two_players)
+      game.increment_turn
+      expect(game.black_turn?).to be true
+      expect(game.white_turn?).to be false
+    end
+  end
+
   context 'scopes' do
     it 'avaliable returns avaliable games' do
       g = FactoryGirl.create(:game, :with_one_player)


### PR DESCRIPTION
### What does this PR do?
Places a turn count on the games model. This is set to 1 (first turn) by default.

Includes 3 helper-style methods placed on the game game model

1) increment_turn
adds one to the current game.turn count

2) white_turn?
returns true for all odd turns (1, 3, 5..) and false otherwise

2) black_turn?
returns true for all even turns (2, 4, 6..) and false otherwise

I also wrote tests (currently passing) for each of these in
specs/models/game_spec

### Additional Comments
This will need to be called when a piece is moving to check that it it the current player's turn

### GIF for how this PR makes me feel
![](https://media.giphy.com/media/l3vR8fg0lzOhMszHa/giphy.gif)
