### PR TITLE
Requires promotion of pawn to another valid piece type when it moves …

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -44,24 +44,23 @@ class Pawn < Piece
     false
   end
 
-  def promote(x, y)
-    if (white? && y == 7) || (black? && y = 0)
-      print "Promote your pawn to a queen, knight, rook, or bishop (q, k, r, b)?"
-      STDOUT.flush  
+  def promote(y)
+    if (white? && y == 7) || (black? && y == 0)
+      print 'Promote your pawn to a queen, knight, rook, or bishop (q, k, r, b)?'
       new_piece = gets.chomp 
-      unless ['q', 'k', 'r', 'b'].include? new_piece.downcase 
-        print "Please select a valid piece (q, k, r, b)?"
-        new_piece = gets.chomp 
-      end      
-      case new_piece.downcase[0,1]
-      when "q"
-        update_attributes(type: "Queen")
-      when "k"
-        update_attributes(type: "Knight")
-      when "r"
-        update_attributes(type: "Rook")
-      when "b"
-        update_attributes(type: "Bishop")
+      unless %w(q k r b).include? new_piece.downcase
+      print 'Please select a valid piece (q, k, r, b)?'
+        new_piece = gets.chomp
+      end
+      case new_piece.downcase[0, 1]
+      when 'q'
+        update_attributes(type: 'Queen')
+      when 'k'
+        update_attributes(type: 'Knight')
+      when 'r'
+        update_attributes(type: 'Rook')
+      when 'b'
+        update_attributes(type: 'Bishop')
       end
     end
   end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -45,11 +45,11 @@ class Pawn < Piece
   end
 
   def promote(y)
-    if (white? && y == 7) || (black? && y == 0)
+    if (white? && y == 7) || (black? && y.zero?)
       print 'Promote your pawn to a queen, knight, rook, or bishop (q, k, r, b)?'
-      new_piece = gets.chomp 
+      new_piece = gets.chomp
       unless %w(q k r b).include? new_piece.downcase
-      print 'Please select a valid piece (q, k, r, b)?'
+        print 'Please select a valid piece (q, k, r, b)?'
         new_piece = gets.chomp
       end
       case new_piece.downcase[0, 1]

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -43,4 +43,26 @@ class Pawn < Piece
     end
     false
   end
+
+  def promote(x, y)
+    if (white? && y == 7) || (black? && y = 0)
+      print "Promote your pawn to a queen, knight, rook, or bishop (q, k, r, b)?"
+      STDOUT.flush  
+      new_piece = gets.chomp 
+      unless ['q', 'k', 'r', 'b'].include? new_piece.downcase 
+        print "Please select a valid piece (q, k, r, b)?"
+        new_piece = gets.chomp 
+      end      
+      case new_piece.downcase[0,1]
+      when "q"
+        update_attributes(type: "Queen")
+      when "k"
+        update_attributes(type: "Knight")
+      when "r"
+        update_attributes(type: "Rook")
+      when "b"
+        update_attributes(type: "Bishop")
+      end
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161120201514) do
+ActiveRecord::Schema.define(version: 20161120201114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -38,4 +38,15 @@ RSpec.describe Pawn, type: :model do
       expect(pawn.valid_move?(4, 6)).to be false
     end
   end
+
+  context 'promote' do
+    it 'allows promotion of pawn to another piece' do
+      g = FactoryGirl.create(:game, :with_two_players)
+      g.pieces.destroy_all
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 6, color: true)
+      puts "Enter letter 'q' for rspec test to pass, an invalid letter to get reprompt, and 'r', 'b', or 'k' to fail."
+      pawn.promote(4, 7)
+      expect(pawn.type).to eq('Queen')
+    end
+  end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Pawn, type: :model do
       g.pieces.destroy_all
       pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 6, color: true)
       puts "Enter letter 'q' for rspec test to pass, an invalid letter to get reprompt, and 'r', 'b', or 'k' to fail."
-      pawn.promote(4, 7)
+      pawn.promote(7)
       expect(pawn.type).to eq('Queen')
     end
   end


### PR DESCRIPTION
### What does this PR do?
Adds Pawn Promotion, which requires the user to select a valid piece to change their pawn to once the pawn reaches the last row (row 7 for white, and row 0 for black). The valid pieces it can change to are Queen, Knight, Rook, and Bishop. 

The user is prompted with the question of what they want to promote to. If a valid response is typed in, the piece type will change to the selected type. Otherwise, they continue to be prompted until they enter a valid piece type. 

### Where should I start?
Changes are all in the pawn model (and pawn_spec.rb).

### How do I manually test this?
I added an rspec test which works correctly. You will be prompted when running rspec to select a piece. Follow the instructions on screen to test it. But essentially selecting 'q' will pass the test, successfully switching the pawn to a queen.
