### PR TITLE
En passant

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -8,10 +8,9 @@ class Pawn < Piece
     if occupying_piece(x, y)
       return true if occupying_piece(x, y).color != color
     end
-    return true if en_passant?(x,y)
+    return true if en_passant?(x, y)
     false
   end
-
 
   def valid_move?(x, y)
     # call super
@@ -23,7 +22,7 @@ class Pawn < Piece
 
     # valid move logic for moving vertically
     if x_coord == x
-      if piece_turn == 0
+      if piece_turn.zero?
         return true if (y - y_coord).abs < 3
         false
       elsif (y - y_coord).abs < 2
@@ -39,16 +38,15 @@ class Pawn < Piece
     end
     false
   end
-  
-  def en_passant?(x, y)
-    y_diff = (y_coord - y).abs
-    return false unless (pos_filled_with_other_color?(x_coord + 1, y_coord) && x == (x_coord + 1)) || (pos_filled_with_other_color?(x_coord - 1, y_coord) && x == (x_coord - 1))
+
+  def en_passant?(x, _y)
+    return false unless (pos_filled_with_other_color?(x_coord + 1, y_coord) && x == (x_coord + 1)) ||
+                        (pos_filled_with_other_color?(x_coord - 1, y_coord) && x == (x_coord - 1))
     opponent_pawn = occupying_piece(x, y_coord)
     return false unless opponent_pawn.piece_turn == 1
     # Makes sure that the last moved piece by the opponent is the same as the opponent pawn
-    last_opponent_piece = game.pieces.where('color = ? and captured = false', !color).order("updated_at").last
+    last_opponent_piece = game.pieces.where('color = ? and captured = false', !color).order('updated_at').last
     return false unless last_opponent_piece == opponent_pawn
     true
-    
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -8,13 +8,14 @@ class Pawn < Piece
     if occupying_piece(x, y)
       return true if occupying_piece(x, y).color != color
     end
+    return true if en_passant?(x,y)
     false
   end
 
-  # TODO: - fix valid_move to implement super
+
   def valid_move?(x, y)
     # call super
-    # return false unless super
+    return false unless super
 
     # prevent pawn from moving backwards
     return false if white? && (y_coord - y) >= 0
@@ -40,7 +41,11 @@ class Pawn < Piece
   end
   
   def en_passant?(x, y)
-    return false unless pos_filled_with_other_color?(x_coord + 1, y_coord) || pos_filled_with_other_color?(x_coord -1 , y_coord)
+    y_diff = (y_coord - y).abs
+    return false unless (pos_filled_with_other_color?(x_coord + 1, y_coord) && x == (x_coord + 1)) || (pos_filled_with_other_color?(x_coord - 1, y_coord) && x == (x_coord - 1))
+    opponent_pawn = occupying_piece(x, y_coord)
+    return false unless opponent_pawn.piece_turn == 1
+    # TODO: a condition to return false when the opponent's last move did not involve the opponent pawn
     true
     
   end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -22,7 +22,7 @@ class Pawn < Piece
 
     # valid move logic for moving vertically
     if x_coord == x
-      if first_move
+      if piece_turn == 0
         return true if (y - y_coord).abs < 3
         false
       elsif (y - y_coord).abs < 2
@@ -37,5 +37,10 @@ class Pawn < Piece
       return capture_move?(x, y)
     end
     false
+  end
+  
+  def en_passant?(x, y)
+    
+    
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -40,7 +40,8 @@ class Pawn < Piece
   end
   
   def en_passant?(x, y)
-    
+    return false unless pos_filled_with_other_color?(x_coord + 1, y_coord) || pos_filled_with_other_color?(x_coord -1 , y_coord)
+    true
     
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -39,6 +39,14 @@ class Pawn < Piece
     false
   end
 
+  def move_to(x, y)
+    if en_passant?(x, y)
+      opponent_pawn = occupying_piece(x, y_coord)
+      opponent_pawn.update_attributes(captured: true)
+    end
+    super
+  end
+
   def en_passant?(x, _y)
     return false unless (pos_filled_with_other_color?(x_coord + 1, y_coord) && x == (x_coord + 1)) ||
                         (pos_filled_with_other_color?(x_coord - 1, y_coord) && x == (x_coord - 1))

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -43,6 +43,7 @@ class Pawn < Piece
     return false unless (pos_filled_with_other_color?(x_coord + 1, y_coord) && x == (x_coord + 1)) ||
                         (pos_filled_with_other_color?(x_coord - 1, y_coord) && x == (x_coord - 1))
     opponent_pawn = occupying_piece(x, y_coord)
+    return false unless opponent_pawn.type == 'Pawn'
     return false unless opponent_pawn.piece_turn == 1
     # Makes sure that the last moved piece by the opponent is the same as the opponent pawn
     last_opponent_piece = game.pieces.where('color = ? and captured = false', !color).order('updated_at').last

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -46,6 +46,8 @@ class Pawn < Piece
     opponent_pawn = occupying_piece(x, y_coord)
     return false unless opponent_pawn.piece_turn == 1
     # TODO: a condition to return false when the opponent's last move did not involve the opponent pawn
+    last_opponent_piece = game.pieces.changed.last
+    return false unless opponent_pawn == last_opponent_piece
     true
     
   end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -45,9 +45,9 @@ class Pawn < Piece
     return false unless (pos_filled_with_other_color?(x_coord + 1, y_coord) && x == (x_coord + 1)) || (pos_filled_with_other_color?(x_coord - 1, y_coord) && x == (x_coord - 1))
     opponent_pawn = occupying_piece(x, y_coord)
     return false unless opponent_pawn.piece_turn == 1
-    # TODO: a condition to return false when the opponent's last move did not involve the opponent pawn
-    last_opponent_piece = game.pieces.changed.last
-    return false unless opponent_pawn == last_opponent_piece
+    # Makes sure that the last moved piece by the opponent is the same as the opponent pawn
+    last_opponent_piece = game.pieces.where('color = ? and captured = false', !color).order("updated_at").last
+    return false unless last_opponent_piece == opponent_pawn
     true
     
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -170,15 +170,10 @@ class Piece < ActiveRecord::Base
     captured_piece.update_attributes(captured: true, x_coord: nil, y_coord: nil)
   end
 
-  # change first_move to false
-  def set_first_move_false!
-    update_attributes(first_move: false)
-  end
-
   def move_to(x, y)
     capture_piece(x, y) if pos_filled?(x, y)
-    update_attributes(x_coord: x, y_coord: y)
-    set_first_move_false!
+    update_attributes(x_coord: x, y_coord: y, piece_turn: piece_turn + 1)
+    
   end
 
   # /// checkmate helpers ///

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -17,7 +17,6 @@ class Piece < ActiveRecord::Base
       return false unless game.full? # ensure two players before move
       return false unless right_color? # ensure same color as turn
       return false unless valid_move?(x, y) # ensure move is legal
-      return false if obstructed?(x, y) # ensure can get to new location
       return false if pos_filled_with_same_color?(x, y) # ensures no piece of same color
 
       # TODO: fail ActiveRecord::Rollback if game.check?(color) # stop move if in check
@@ -95,23 +94,13 @@ class Piece < ActiveRecord::Base
   def valid_move?(new_x, new_y)
     board_size = 7
     # piece cannot move to same position
-    if new_x == x_coord && new_y == y_coord
-      return false
-    end
-    # piece cannot move on top of it's own color - IR - not sure what the code below is, commenting out
-    # unless new_x != @new_x || new_y != @new_y
-    #   return false
-    # end
-
+    return false if new_x == x_coord && new_y == y_coord
     # rubocop:disable NumericPredicate
     # piece cannot move off game board
-    if new_x > board_size || new_y > board_size || new_x < 0 || new_y < 0
-      return false
-    end
-    # no piece can be obstructed
-    if obstructed?(new_x, new_y)
-      return false
-    end
+    return false if new_x > board_size || new_y > board_size || new_x < 0 || new_y < 0
+    # move cannot be obstructed by another piece
+    return false if obstructed?(new_x, new_y)
+
     true
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -173,7 +173,6 @@ class Piece < ActiveRecord::Base
   def move_to(x, y)
     capture_piece(x, y) if pos_filled?(x, y)
     update_attributes(x_coord: x, y_coord: y, piece_turn: piece_turn + 1)
-    
   end
 
   # /// checkmate helpers ///

--- a/db/migrate/20161202061628_add_piece_turn_column_and_remove_first_move_column.rb
+++ b/db/migrate/20161202061628_add_piece_turn_column_and_remove_first_move_column.rb
@@ -1,0 +1,6 @@
+class AddPieceTurnColumnAndRemoveFirstMoveColumn < ActiveRecord::Migration
+  def change
+    add_column :pieces, :piece_move, :integer, default: 0
+    remove_column :pieces, :first_move, :boolean
+  end
+end

--- a/db/migrate/20161202070351_rename_piece_move_to_piece_turn.rb
+++ b/db/migrate/20161202070351_rename_piece_move_to_piece_turn.rb
@@ -1,0 +1,5 @@
+class RenamePieceMoveToPieceTurn < ActiveRecord::Migration
+  def change
+    rename_column :pieces, :piece_move, :piece_turn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161127032058) do
+ActiveRecord::Schema.define(version: 20161202061628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,9 +33,9 @@ ActiveRecord::Schema.define(version: 20161127032058) do
     t.integer  "y_coord"
     t.boolean  "captured",   default: false
     t.integer  "game_id"
-    t.boolean  "first_move", default: true
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "piece_move", default: 0
   end
 
   create_table "players", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202061628) do
+ActiveRecord::Schema.define(version: 20161202070351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 20161202061628) do
     t.integer  "game_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "piece_move", default: 0
+    t.integer  "piece_turn", default: 0
   end
 
   create_table "players", force: true do |t|

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -22,8 +22,8 @@ FactoryGirl.define do
       after :create do |g|
         g.pieces.destroy_all
         # white rook checks black king
-        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false, captured: false)
-        g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true, first_move: false, captured: false)
+        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, captured: false)
+        g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true, captured: false)
       end
     end
 
@@ -32,8 +32,8 @@ FactoryGirl.define do
       after :create do |g|
         g.pieces.destroy_all
         # white rook checks black king
-        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false, captured: false)
-        g.pieces.create(type: 'Rook', x_coord: 0, y_coord: 4, color: true, first_move: false, captured: false)
+        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, captured: false)
+        g.pieces.create(type: 'Rook', x_coord: 0, y_coord: 4, color: true, captured: false)
       end
     end
 
@@ -42,8 +42,8 @@ FactoryGirl.define do
       after :create do |g|
         g.pieces.destroy_all
         # white rook checks black king
-        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false, captured: false)
-        g.pieces.create(type: 'Bishop', x_coord: 2, y_coord: 5, color: true, first_move: false, captured: false)
+        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, captured: false)
+        g.pieces.create(type: 'Bishop', x_coord: 2, y_coord: 5, color: true, captured: false)
       end
     end
 
@@ -52,8 +52,8 @@ FactoryGirl.define do
       after :create do |g|
         g.pieces.destroy_all
         # white rook checks black king
-        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false, captured: false)
-        g.pieces.create(type: 'Knight', x_coord: 2, y_coord: 6, color: true, first_move: false, captured: false)
+        g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, captured: false)
+        g.pieces.create(type: 'Knight', x_coord: 2, y_coord: 6, color: true, captured: false)
       end
     end
 
@@ -61,35 +61,35 @@ FactoryGirl.define do
       after :create do |g|
         g.pieces.destroy_all
         # test case board from: https://gist.github.com/kenmazaika/92b81db9e977578c8d94
-        g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 1, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 1, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 1, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 5, y_coord: 1, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 6, y_coord: 1, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 7, y_coord: 1, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Rook', x_coord: 0, y_coord: 0, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Knight', x_coord: 1, y_coord: 0, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'King', x_coord: 3, y_coord: 0, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Bishop', x_coord: 5, y_coord: 0, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Knight', x_coord: 6, y_coord: 0, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 0, color: false, first_move: true, captured: false)
-        g.pieces.create(type: 'Rook', x_coord: 0, y_coord: 7, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 7, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'King', x_coord: 3, y_coord: 7, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Queen', x_coord: 4, y_coord: 7, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Bishop', x_coord: 5, y_coord: 7, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Knight', x_coord: 6, y_coord: 7, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 6, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 3, y_coord: 6, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 6, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 5, y_coord: 6, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 6, y_coord: 6, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 7, y_coord: 6, color: true, first_move: true, captured: false)
-        g.pieces.create(type: 'Bishop', x_coord: 0, y_coord: 5, color: true, first_move: false, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 5, color: true, first_move: false, captured: false)
-        g.pieces.create(type: 'Bishop', x_coord: 7, y_coord: 5, color: false, first_move: false, captured: false)
-        g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, color: false, first_move: false, captured: false)
-        g.pieces.create(type: 'Knight', x_coord: 3, y_coord: 3, color: true, first_move: false, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 1, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 1, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 1, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 5, y_coord: 1, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 6, y_coord: 1, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 7, y_coord: 1, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Rook', x_coord: 0, y_coord: 0, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Knight', x_coord: 1, y_coord: 0, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'King', x_coord: 3, y_coord: 0, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Bishop', x_coord: 5, y_coord: 0, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Knight', x_coord: 6, y_coord: 0, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 0, color: false, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Rook', x_coord: 0, y_coord: 7, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 7, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'King', x_coord: 3, y_coord: 7, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Queen', x_coord: 4, y_coord: 7, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Bishop', x_coord: 5, y_coord: 7, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Knight', x_coord: 6, y_coord: 7, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 6, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 3, y_coord: 6, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 6, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 5, y_coord: 6, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 6, y_coord: 6, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 7, y_coord: 6, color: true, piece_turn: 0, captured: false)
+        g.pieces.create(type: 'Bishop', x_coord: 0, y_coord: 5, color: true, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 5, color: true, captured: false)
+        g.pieces.create(type: 'Bishop', x_coord: 7, y_coord: 5, color: false, captured: false)
+        g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, color: false, captured: false)
+        g.pieces.create(type: 'Knight', x_coord: 3, y_coord: 3, color: true, captured: false)
       end
     end
   end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -129,58 +129,58 @@ RSpec.describe Game, type: :model do
   context 'checkmate?' do
     it 'returns false when checking piece can be captured' do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false, captured: false)
-      g.pieces.create(type: 'Rook', x_coord: 1, y_coord: 7, color: true, first_move: false, captured: false)
+      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, captured: false)
+      g.pieces.create(type: 'Rook', x_coord: 1, y_coord: 7, color: true, captured: false)
       expect(g.checkmate?(false)).to be false
     end
     it 'returns false when king can move itself out of check' do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false, captured: false)
-      g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true, first_move: false, captured: false)
+      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, captured: false)
+      g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true, captured: false)
       expect(g.checkmate?(false)).to be false
     end
     it 'returns false when checking piece can be blocked by another piece' do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false)
-      g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true, first_move: false)
-      g.pieces.create(type: 'Queen', x_coord: 0, y_coord: 5, color: true, first_move: false)
-      g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 6, color: false, first_move: false)
+      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false)
+      g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true)
+      g.pieces.create(type: 'Queen', x_coord: 0, y_coord: 5, color: true)
+      g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 6, color: false)
       # black bishop can move to (1,7) to block white rook from checking black king
-      g.pieces.create(type: 'Bishop', x_coord: 3, y_coord: 5, color: false, first_move: false)
+      g.pieces.create(type: 'Bishop', x_coord: 3, y_coord: 5, color: false)
       expect(g.checkmate?(false)).to be false
     end
     it 'returns true when game state is in checkmate' do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false, first_move: false)
-      g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true, first_move: false)
-      g.pieces.create(type: 'Queen', x_coord: 0, y_coord: 5, color: true, first_move: false)
+      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false)
+      g.pieces.create(type: 'Rook', x_coord: 2, y_coord: 7, color: true)
+      g.pieces.create(type: 'Queen', x_coord: 0, y_coord: 5, color: true)
       expect(g.checkmate?(false)).to be true
     end
   end
   context 'stalemate?' do
     it 'returns false when king can move into check but has other places to go' do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'Bishop', x_coord: 4, y_coord: 5, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 4, y_coord: 7, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 3, y_coord: 0, first_move: false, color: false)
+      g.pieces.create(type: 'Bishop', x_coord: 4, y_coord: 5, color: true)
+      g.pieces.create(type: 'King', x_coord: 4, y_coord: 7, color: true)
+      g.pieces.create(type: 'King', x_coord: 3, y_coord: 0, color: false)
 
       expect(g.stalemate?(false)).to be false
     end
 
     it "returns true when king's next move results in a check" do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'Queen', x_coord: 6, y_coord: 2, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 5, y_coord: 1, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 7, y_coord: 0, first_move: false, color: false)
+      g.pieces.create(type: 'Queen', x_coord: 6, y_coord: 2, color: true)
+      g.pieces.create(type: 'King', x_coord: 5, y_coord: 1, color: true)
+      g.pieces.create(type: 'King', x_coord: 7, y_coord: 0, color: false)
 
       expect(g.stalemate?(false)).to be true
     end
     it 'returns true when moving a remaining piece results in a check' do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 7, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 1, y_coord: 5, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, first_move: false, color: false)
-      g.pieces.create(type: 'Bishop', x_coord: 1, y_coord: 7, first_move: false, color: false)
+      g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 7, color: true)
+      g.pieces.create(type: 'King', x_coord: 1, y_coord: 5, color: true)
+      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false)
+      g.pieces.create(type: 'Bishop', x_coord: 1, y_coord: 7, color: false)
 
       expect(g.stalemate?(false)).to be true
     end
@@ -193,10 +193,10 @@ RSpec.describe Game, type: :model do
 
     it 'returns false when a piece is in check but can be blocked by a remaining piece' do
       g = FactoryGirl.create(:game, :with_two_players)
-      g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 7, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 1, y_coord: 5, first_move: false, color: true)
-      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, first_move: false, color: false)
-      g.pieces.create(type: 'Bishop', x_coord: 4, y_coord: 4, first_move: false, color: false)
+      g.pieces.create(type: 'Rook', x_coord: 7, y_coord: 7, color: true)
+      g.pieces.create(type: 'King', x_coord: 1, y_coord: 5, color: true)
+      g.pieces.create(type: 'King', x_coord: 0, y_coord: 7, color: false)
+      g.pieces.create(type: 'Bishop', x_coord: 4, y_coord: 4, color: false)
       expect(g.stalemate?(false)).to be false
     end
   end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Pawn, type: :model do
       expect(pawn.valid_move?(4, 6)).to be false
     end
   end
-  
+
   context 'en_passant?' do
     it 'returns true when a pawn move is a valid en passant capture' do
       g = FactoryGirl.create(:game, :with_two_players)
@@ -48,36 +48,36 @@ RSpec.describe Pawn, type: :model do
       expect(pawn.valid_move?(0, 2)).to be true
       expect(pawn.en_passant?(2, 2)).to be false
       expect(pawn.valid_move?(2, 2)).to be false
-      
+
       opp_pawn.destroy
       g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 1, color: true)
-      
+
       expect(pawn.en_passant?(2, 2)).to be true
       expect(pawn.valid_move?(2, 2)).to be true
       expect(pawn.en_passant?(0, 2)).to be false
       expect(pawn.valid_move?(0, 2)).to be false
     end
-    
+
     it 'returns true when a pawn move is a valid en passant capture, where pawn is on an edge (x_coord = 0)' do
       g = FactoryGirl.create(:game, :with_two_players)
       # black's turn (even) to attempt en passant capture on white pawn
       g.turn = 6
       pawn = g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 2, color: false)
       g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 1, color: true)
-      
+
       expect(pawn.en_passant?(1, 2)).to be true
     end
-    
+
     it " returns false when the opponent's pawn did not move forward two ranks from its starting position" do
       g = FactoryGirl.create(:game, :with_two_players)
       # black's turn (even) to attempt en passant capture on white pawn
       g.turn = 6
       pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
       g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 2, piece_turn: 1, color: true)
-      
+
       expect(pawn.en_passant?(0, 2)).to be false
     end
-    
+
     it "returns false when the opponent's pawn is not on its first move" do
       g = FactoryGirl.create(:game, :with_two_players)
       # black's turn (even) to attempt en passant capture on white pawn
@@ -85,11 +85,11 @@ RSpec.describe Pawn, type: :model do
       pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
       g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 2, color: true)
       g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 2, color: true)
-      
+
       expect(pawn.en_passant?(0, 2)).to be false
       expect(pawn.en_passant?(2, 2)).to be false
     end
-    
+
     it "returns false when the opponent's last move did not utilize the pawn to be captured" do
       g = FactoryGirl.create(:game, :with_two_players)
       # black's turn (even) to attempt en passant capture on white pawn
@@ -98,14 +98,12 @@ RSpec.describe Pawn, type: :model do
       pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
       g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 1, color: true)
       g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 1, color: true)
-      
-      not_pawn.move_to(2,4)
+
+      not_pawn.move_to(2, 4)
       g.increment_turn
-      
+
       expect(pawn.en_passant?(0, 2)).to be false
       expect(pawn.en_passant?(2, 2)).to be false
     end
-    
-    
   end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -94,10 +94,11 @@ RSpec.describe Pawn, type: :model do
       g = FactoryGirl.create(:game, :with_two_players)
       # black's turn (even) to attempt en passant capture on white pawn
       g.turn = 5
+      not_pawn = g.pieces.create(type: 'Bishop', x_coord: 0, y_coord: 6, piece_turn: 1, color: true)
       pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
       g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 1, color: true)
       g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 1, color: true)
-      not_pawn = g.pieces.create(type: 'Bishop', x_coord: 0, y_coord: 6, piece_turn: 1, color: true)
+      
       not_pawn.move_to(2,4)
       g.increment_turn
       

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -115,5 +115,19 @@ RSpec.describe Pawn, type: :model do
       expect(pawn.en_passant?(0, 2)).to be false
       expect(pawn.en_passant?(2, 2)).to be false
     end
+
+    it 'changes captured attribute to true once move_to method is called' do
+      g = FactoryGirl.create(:game, :with_two_players)
+      g.turn = 6
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, captured: false, piece_turn: 2, color: false)
+      capture_pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, captured: false, piece_turn: 1, color: true)
+
+      pawn.move_to(1, 2)
+      pawn.reload
+      capture_pawn.reload
+      expect(pawn.captured).to be false
+      expect(pawn).to have_attributes(x_coord: 1, y_coord: 2)
+      expect(capture_pawn.captured).to be true
+    end
   end
 end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe Pawn, type: :model do
       expect(pawn.en_passant?(1, 2)).to be true
     end
 
+    it 'returns false when the piece to be captured is not a pawn' do
+      g = FactoryGirl.create(:game, :with_two_players)
+      # black's turn (even) to attempt en passant capture on white pawn
+      g.turn = 6
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 2, color: false)
+      g.pieces.create(type: 'Bishop', x_coord: 1, y_coord: 3, piece_turn: 1, color: true)
+
+      expect(pawn.en_passant?(1, 2)).to be false
+    end
+
     it " returns false when the opponent's pawn did not move forward two ranks from its starting position" do
       g = FactoryGirl.create(:game, :with_two_players)
       # black's turn (even) to attempt en passant capture on white pawn

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -37,16 +37,35 @@ RSpec.describe Pawn, type: :model do
   end
   
   context 'en_passant?' do
-    it 'returns true when a pawn is a valid en passant capture' do
+    it 'returns true when a pawn move is a valid en passant capture' do
       g = FactoryGirl.create(:game, :with_two_players)
       # black's turn (even) to attempt en passant capture on white pawn
       g.turn = 6
       pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
-      g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 1, color: true)
+      opp_pawn = g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 1, color: true)
+
+      expect(pawn.en_passant?(0, 2)).to be true
+      expect(pawn.valid_move?(0, 2)).to be true
+      expect(pawn.en_passant?(2, 2)).to be false
+      expect(pawn.valid_move?(2, 2)).to be false
+      
+      opp_pawn.destroy
       g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 1, color: true)
       
-      expect(pawn.en_passant?(0, 2)).to be true
       expect(pawn.en_passant?(2, 2)).to be true
+      expect(pawn.valid_move?(2, 2)).to be true
+      expect(pawn.en_passant?(0, 2)).to be false
+      expect(pawn.valid_move?(0, 2)).to be false
+    end
+    
+    it 'returns true when a pawn move is a valid en passant capture, where pawn is on an edge (x_coord = 0)' do
+      g = FactoryGirl.create(:game, :with_two_players)
+      # black's turn (even) to attempt en passant capture on white pawn
+      g.turn = 6
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 2, color: false)
+      g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 1, color: true)
+      
+      expect(pawn.en_passant?(1, 2)).to be true
     end
     
     it " returns false when the opponent's pawn did not move forward two ranks from its starting position" do
@@ -80,7 +99,7 @@ RSpec.describe Pawn, type: :model do
       g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 1, color: true)
       not_pawn = g.pieces.create(type: 'Bishop', x_coord: 0, y_coord: 6, piece_turn: 1, color: true)
       not_pawn.move_to(2,4)
-      game.increment_turn
+      g.increment_turn
       
       expect(pawn.en_passant?(0, 2)).to be false
       expect(pawn.en_passant?(2, 2)).to be false

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -5,34 +5,87 @@ RSpec.describe Pawn, type: :model do
   context 'valid_move?' do
     it 'allows valid vertical pawn move when first move' do
       g = FactoryGirl.create(:game, :with_two_players)
-      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, first_move: true, color: true)
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, piece_turn: 0, color: true)
       expect(pawn.valid_move?(4, 3)).to be true
       expect(pawn.valid_move?(4, 4)).to be true
     end
 
     it 'does not allow invalid vertical pawn move when first move' do
       g = FactoryGirl.create(:game, :with_two_players)
-      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, first_move: true, color: true)
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, piece_turn: 0, color: true)
       expect(pawn.valid_move?(4, 5)).to be false
       expect(pawn.valid_move?(4, 6)).to be false
     end
 
     it 'allows valid diagonal move' do
       g = FactoryGirl.create(:game, :with_two_players)
-      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, first_move: true, color: true)
-      g.pieces.create(type: 'Queen', x_coord: 3, y_coord: 3, first_move: true, color: false)
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, piece_turn: 0, color: true)
+      g.pieces.create(type: 'Queen', x_coord: 3, y_coord: 3, piece_turn: 0, color: false)
 
       expect(pawn.valid_move?(3, 3)).to be true
     end
 
     it 'does not allow other invalid moves' do
       g = FactoryGirl.create(:game, :with_two_players)
-      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, first_move: true, color: true)
-      g.pieces.create(type: 'Pawn', x_coord: 3, y_coord: 3, first_move: true, color: true)
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 4, y_coord: 2, piece_turn: 0, color: true)
+      g.pieces.create(type: 'Pawn', x_coord: 3, y_coord: 3, piece_turn: 0, color: true)
       expect(pawn.valid_move?(3, 2)).to be false
       expect(pawn.valid_move?(2, 7)).to be false
       expect(pawn.valid_move?(3, 3)).to be false
       expect(pawn.valid_move?(4, 6)).to be false
     end
+  end
+  
+  context 'en_passant?' do
+    it 'returns true when a pawn is a valid en passant capture' do
+      g = FactoryGirl.create(:game, :with_two_players)
+      # black's turn (even) to attempt en passant capture on white pawn
+      g.turn = 6
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
+      g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 1, color: true)
+      g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 1, color: true)
+      
+      expect(pawn.en_passant?(0, 2)).to be true
+      expect(pawn.en_passant?(2, 2)).to be true
+    end
+    
+    it " returns false when the opponent's pawn did not move forward two ranks from its starting position" do
+      g = FactoryGirl.create(:game, :with_two_players)
+      # black's turn (even) to attempt en passant capture on white pawn
+      g.turn = 6
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
+      g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 2, piece_turn: 1, color: true)
+      
+      expect(pawn.en_passant?(0, 2)).to be false
+    end
+    
+    it "returns false when the opponent's pawn is not on its first move" do
+      g = FactoryGirl.create(:game, :with_two_players)
+      # black's turn (even) to attempt en passant capture on white pawn
+      g.turn = 6
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
+      g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 2, color: true)
+      g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 2, color: true)
+      
+      expect(pawn.en_passant?(0, 2)).to be false
+      expect(pawn.en_passant?(2, 2)).to be false
+    end
+    
+    it "returns false when the opponent's last move did not utilize the pawn to be captured" do
+      g = FactoryGirl.create(:game, :with_two_players)
+      # black's turn (even) to attempt en passant capture on white pawn
+      g.turn = 5
+      pawn = g.pieces.create(type: 'Pawn', x_coord: 1, y_coord: 3, piece_turn: 2, color: false)
+      g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 3, piece_turn: 1, color: true)
+      g.pieces.create(type: 'Pawn', x_coord: 2, y_coord: 3, piece_turn: 1, color: true)
+      not_pawn = g.pieces.create(type: 'Bishop', x_coord: 0, y_coord: 6, piece_turn: 1, color: true)
+      not_pawn.move_to(2,4)
+      game.increment_turn
+      
+      expect(pawn.en_passant?(0, 2)).to be false
+      expect(pawn.en_passant?(2, 2)).to be false
+    end
+    
+    
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -35,19 +35,19 @@ RSpec.describe Piece, type: :model do
 
   context 'colors' do
     it 'white? should return true if color is white' do
-      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, first_move: true, color: true)
+      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, piece_turn: 0, color: true)
       expect(piece.white?).to be true
     end
     it 'white? should return false if color is black' do
-      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, first_move: true, color: false)
+      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, piece_turn: 0, color: false)
       expect(piece.white?).to be false
     end
     it 'black? should return true if color is black' do
-      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, first_move: true, color: false)
+      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, piece_turn: 0, color: false)
       expect(piece.black?).to be true
     end
     it 'black? should return false if color is white' do
-      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, first_move: true, color: true)
+      piece = Piece.create(type: 'Pawn', x_coord: 3, y_coord: 3, piece_turn: 0, color: true)
       expect(piece.black?).to be false
     end
     it 'right_color? should return true for black piece on black turns' do

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -81,4 +81,16 @@ RSpec.describe Piece, type: :model do
       expect(piece.occupying_piece(4, 7)).to eq(Piece.where(x_coord: 4, y_coord: 7).first)
     end
   end
+
+  context 'move_to' do
+    it 'should increment piece_turn by one' do
+      g = FactoryGirl.create(:game, :with_two_players)
+      p = g.pieces.create(type: 'Pawn', x_coord: 0, y_coord: 1, piece_turn: 0, color: true)
+      expect(p.piece_turn).to be(0)
+      p.move_to(0, 2)
+      expect(p.piece_turn).to be(1)
+      p.move_to(0, 3)
+      expect(p.piece_turn).to be(2)
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?
Adds en_passant capture rule for pawns and implements en_passant? method to be called from capture_move?, which is a part of the valid_move? method.

En passant is a special pawn capture that can only occur **immediately** after a pawn has moved up 2 squares in the previous move. If so, the opposing pawns can capture that piece in a diagonal move past the piece, like so:
![](https://upload.wikimedia.org/wikipedia/commons/0/09/Ajedrez_animaci%C3%B3n_en_passant.gif)
https://en.wikipedia.org/wiki/En_passant

en_passant? checks for 4 conditions:
1. Checks neighboring horizontal squares to see if they are populated by an opponent piece and that they must be in the same x-coordinate as the destination.
2. Checks to see if the opponent piece is actually a pawn
3. Checks that it is the opponent pawn's first move
4. Check that the last moved piece by the opponent is the same as the opponent pawn in question

### Where should I start?
After pulling, make sure to run rake db:migrate and rake db:migrate RAILS_ENV=development.
You might also have to go on rails console and run Game.destroy_all.

**db/schema.db** - Note that first_move column has been removed and piece_turn has been added in its place. piece_turn defaults at 0 for all pieces and increments by 1 for every move that the particular piece takes. I also removed all references to first_move in the project and replaced them with piece_turn. I tweaked some code in move_to (piece.rb) and a condition in pawn.rb in order for the code to work with a default value of 0. 
**app/models/pawn.rb** - en_passant method is integrated with capture_move? method, which in turn works with valid_move. I also added a super call in valid_move.
**spec/models/pawn_spec.rb** - Relevant tests are in this file.
**spec/models/piece_spec.rb** - Added tests to make sure that piece_turn increments when a piece is moved (via move_to).


### How do I manually test this?
rspec 'spec/models/pawn_spec.rb'
rpsec 'spec/models/piece_spec.rb'

### Additional Comments
I'm concerned that condition number 4 for en_passant might be too resource-intensive of a condition to fetch the last moved piece of an opponent. If anyone can think of a better, more SQL-friendly way to do this, let me know.

### Trello story
https://trello.com/c/805iBKaa/35-en-passant

### GIF for how this PR makes me feel
![](https://media.giphy.com/media/E0GEllFSWg8YU/giphy.gif)
