### PR TITLE
Precompile

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,6 @@ Rails.application.configure do
 
   # Do fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = true
-  
 
   # Generate digests for assets URLs.
   config.assets.digest = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,6 +31,7 @@ Rails.application.configure do
 
   # Do fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = true
+  
 
   # Generate digests for assets URLs.
   config.assets.digest = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,8 +29,8 @@ Rails.application.configure do
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
-  # Don't fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # Do fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = true
 
   # Generate digests for assets URLs.
   config.assets.digest = true


### PR DESCRIPTION
### What does this PR do?
Heroku needs assets to precompile.

The stylesheets aren't currently doing so, so the production app has no styles.

This is no good and an easy fix