### PR TITLE
Minor board fixes, logic fixes

### DIFF
--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -8,6 +8,7 @@
 }
 .board {
   width: 90%;
+  border-collapse: collapse;
   max-width: 400px;
   min-width: 200px;
   margin: auto;
@@ -15,8 +16,10 @@
   flex-direction: column;
   box-shadow: 0px 20px 20px -18px #aaa;
   transition: all 150ms ease;
+  
   .row {
     width: 100%;
+    margin: 0;
     display: flex;
     flex-direction: row;
   }
@@ -58,10 +61,10 @@
 
 }
 
-.board:hover{
-  transform: translate3d(0,.2em,0);
-  box-shadow: 0px 10px 20px -12px #aaa;
-}
+// .board:hover{
+//   transform: translate3d(0,.2em,0);
+//   box-shadow: 0px 10px 20px -12px #aaa;
+// }
 
 .row:nth-child(odd) .square:nth-child(even), .row:nth-child(even) .square:nth-child(odd) {
  background-color: #eddede;

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -10,4 +10,20 @@ class Bishop < Piece
     return true if x_dist == y_dist && super
     false
   end
+
+  def correct_moves
+    x0 = x_coord
+    y0 = y_coord
+    limit = 7
+    moves_array = []
+    (-limit..limit).each do |i|
+      x0 = x_coord + i
+      y0 = y_coord + i
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+      x0 = x_coord + i
+      y0 = y_coord - i
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+    end
+    moves_array
+  end
 end

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -17,6 +17,7 @@ class Bishop < Piece
     limit = 7
     moves_array = []
     (-limit..limit).each do |i|
+      # rubocop:disable NumericPredicate
       x0 = x_coord + i
       y0 = y_coord + i
       moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -108,7 +108,6 @@ class Game < ActiveRecord::Base
   end
 
   def stalemate?(player_color)
-    king = pieces.find_by(type: 'King', color: player_color)
     # checks if the player is in check
     return false if check?(player_color)
     # check if any legal moves are available without going into check for remaining pieces

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -111,12 +111,11 @@ class Game < ActiveRecord::Base
     king = pieces.find_by(type: 'King', color: player_color)
     # checks if the player is in check
     return false if check?(player_color)
-    # # check if any legal moves are available without going into check for remaining pieces
-    # uncaptured_pieces((player_color).each do |piece|
-    #   # only takes one legal move to return stalemate false
-    #   return false if piece.move_out_of_check?
-      
-    # end
+    # check if any legal moves are available without going into check for remaining pieces
+    uncaptured_pieces(player_color).each do |piece|
+      # only takes one legal move to return stalemate false
+      return false if piece.move_out_of_check?
+    end
     true
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -84,7 +84,7 @@ class Game < ActiveRecord::Base
     false
   end
 
-  def checking_piece
+  def show_checking_piece
     "#{@checking_piece.type} (#{@checking_piece.x_coord}, #{@checking_piece.y_coord})"
   end
 
@@ -112,6 +112,13 @@ class Game < ActiveRecord::Base
     return false if check?(player_color)
     # checks if all possible moves lead to king moving into check
     return false if king.move_out_of_check?
+
+    # # check if any legal moves are available without going into check
+    # uncaptured_pieces((player_color).each do |piece|
+    #   next if piece.type == 'King'
+    #   return false if piece.valid_move?()
+
+    # end
     true
   end
 

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -44,7 +44,8 @@ class King < Piece
     y0 = y_coord
     correct_moves.each do |move|
       # call check? to determine if any available valid move is able to get king out of check
-      update_attributes(x_coord: move[0], y_coord: move[1]) if valid_move?(move[0], move[1])
+      next unless valid_move?(move[0], move[1])
+      update_attributes(x_coord: move[0], y_coord: move[1])
       return true unless game.check?(color)
       # reset possible moves to starting position
       update_attributes(x_coord: x0, y_coord: y0)

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -12,44 +12,19 @@ class King < Piece
   end
 
   def correct_moves
-    piece = Piece.find(id)
-    x0 = piece.x_coord
-    y0 = piece.y_coord
-
-    # available moves for king
-    up = [x0, y0 + 1]
-    down = [x0, y0 - 1]
-    right = [x0 + 1, y0]
-    left = [x0 - 1, y0]
-
-    valid_moves = []
-
-    # valid move only if
-    move_up = y0 != 7
-    move_down = y0.nonzero?
-    move_left = x0.nonzero?
-    move_right = x0 != 7
-
-    valid_moves.push(up) if move_up
-    valid_moves.push(down) if move_down
-    valid_moves.push(left) if move_left
-    valid_moves.push(right) if move_right
-
-    valid_moves
-  end
-
-  # this method does not care whether or not game state is currently in check
-  def move_out_of_check?
     x0 = x_coord
     y0 = y_coord
-    correct_moves.each do |move|
-      # call check? to determine if any available valid move is able to get king out of check
-      next unless valid_move?(move[0], move[1])
-      update_attributes(x_coord: move[0], y_coord: move[1])
-      return true unless game.check?(color)
-      # reset possible moves to starting position
-      update_attributes(x_coord: x0, y_coord: y0)
+    limit = 1
+    moves_array = []
+    # x-direction
+    (-limit..limit).each do |i|
+      x0 = x_coord + i
+      # y- direction
+      (-limit..limit).each do |j|
+        y0 = y_coord + j
+        moves_array << [x0, y0] unless x0 == x_coord && y0 == y_coord
+      end
     end
-    false
+    moves_array
   end
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -30,6 +30,7 @@ class Knight < Piece
       (-limit..limit).each do |j|
         y0 = y_coord + j
         if valid_move?(x0, y0)
+          # rubocop:disable NumericPredicate
           moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
         end
       end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -17,4 +17,23 @@ class Knight < Piece
   def obstructed?(_x, _y)
     false
   end
+
+  def correct_moves
+    x0 = x_coord
+    y0 = y_coord
+    limit = 3
+    moves_array = []
+    # x-direction
+    (-limit..limit).each do |i|
+      x0 = x_coord + i
+      # y- direction
+      (-limit..limit).each do |j|
+        y0 = y_coord + j
+        if valid_move?(x0, y0)
+          moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+        end
+      end
+    end
+    moves_array
+  end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -43,6 +43,7 @@ class Pawn < Piece
     if en_passant?(x, y)
       opponent_pawn = occupying_piece(x, y_coord)
       opponent_pawn.update_attributes(captured: true)
+      reload
     end
     super
   end
@@ -57,5 +58,18 @@ class Pawn < Piece
     last_opponent_piece = game.pieces.where('color = ? and captured = false', !color).order('updated_at').last
     return false unless last_opponent_piece == opponent_pawn
     true
+  end
+
+  def correct_moves
+    x0 = x_coord
+    y0 = y_coord
+    limit = 2
+    moves_array = []
+    (-limit..limit).each do |i|
+      x0 = x_coord
+      y0 = y_coord + i
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+    end
+    moves_array
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -68,6 +68,7 @@ class Pawn < Piece
     (-limit..limit).each do |i|
       x0 = x_coord
       y0 = y_coord + i
+      # rubocop:disable NumericPredicate
       moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
     end
     moves_array

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -209,16 +209,18 @@ class Piece < ActiveRecord::Base
   def move_out_of_check?
     x0 = x_coord
     y0 = y_coord
+    result = false
     correct_moves.each do |move|
       # call check? to determine if any available valid move is able to get king out of check
       next unless valid_move?(move[0], move[1])
       update_attributes(x_coord: move[0], y_coord: move[1])
       reload
-      return true unless game.check?(color)
+      result = true unless game.check?(color)
       # reset possible moves to starting position
       update_attributes(x_coord: x0, y_coord: y0)
       reload
+      return true if result == true
     end
-    false
+    result
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -193,7 +193,6 @@ class Piece < ActiveRecord::Base
   def block_check?(king)
     # array of coordinates between the king and the checking piece
     check_squares = squares_between(king.x_coord, king.y_coord)
-    return false if check_squares[0].nil?
     potential_blockers = game.uncaptured_pieces(king.color)
     potential_blockers.each do |piece|
       next if piece.type == 'King'

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -17,13 +17,13 @@ class Piece < ActiveRecord::Base
       return false unless game.full? # ensure two players before move
       return false unless right_color? # ensure same color as turn
       return false unless valid_move?(x, y) # ensure move is legal
-      
+
       # TODO: fail ActiveRecord::Rollback if game.check?(color) # stop move if in check
       # TODO fail ActiveRecord::Rollback if obstructed?
 
       move_to(x, y)
       reload
-      fail ActiveRecord::Rollback if game.check?(color) # ensure that move does not result in check
+      raise ActiveRecord::Rollback if game.check?(color) # ensure that move does not result in check
 
       game.increment_turn
       # TODO: update game status if appropriate...?

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -193,7 +193,7 @@ class Piece < ActiveRecord::Base
   def block_check?(king)
     # array of coordinates between the king and the checking piece
     check_squares = squares_between(king.x_coord, king.y_coord)
-    return false if check_squares == [nil, nil]
+    return false if check_squares[0].nil?
     potential_blockers = game.uncaptured_pieces(king.color)
     potential_blockers.each do |piece|
       next if piece.type == 'King'
@@ -203,5 +203,4 @@ class Piece < ActiveRecord::Base
     end
     false
   end
-  # ////////////////////////////
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -13,21 +13,27 @@ class Queen < Piece
     y0 = y_coord
     limit = 7
     moves_array = []
-    (-limit..limit).each do |i|
+    (-limit..limit).each do |_i|
+      # rubocop:disable NumericPredicate
       # vertical and horizontal
-      x0 = x_coord + i
-      y0 = y_coord
-      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
-      x0 = x_coord
-      y0 = y_coord + i
-      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
-      # diagonal
-      x0 = x_coord + i
-      y0 = y_coord + i
-      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
-      x0 = x_coord + i
-      y0 = y_coord - i
-      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+      4.times do |i|
+        if i == 0
+          x0 = x_coord + i
+          y0 = y_coord
+        elsif i == 1
+          x0 = x_coord
+          y0 = y_coord + i
+        else
+          # diagonal
+          x0 = x_coord + i
+          y0 = if i == 2
+                 y_coord + i
+               else
+                 y_coord - i
+               end
+        end
+        moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+      end
     end
     moves_array
   end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -7,4 +7,28 @@ class Queen < Piece
   def valid_move?(new_x, new_y)
     (x_coord == new_x || y_coord == new_y || (x_coord - new_x).abs == (y_coord - new_y).abs) && super
   end
+
+  def correct_moves
+    x0 = x_coord
+    y0 = y_coord
+    limit = 7
+    moves_array = []
+    (-limit..limit).each do |i|
+      # vertical and horizontal
+      x0 = x_coord + i
+      y0 = y_coord
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+      x0 = x_coord
+      y0 = y_coord + i
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+      # diagonal
+      x0 = x_coord + i
+      y0 = y_coord + i
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+      x0 = x_coord + i
+      y0 = y_coord - i
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+    end
+    moves_array
+  end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -8,4 +8,20 @@ class Rook < Piece
     return true if (new_x == x_coord || new_y == y_coord) && super
     false
   end
+
+  def correct_moves
+    x0 = x_coord
+    y0 = y_coord
+    limit = 7
+    moves_array = []
+    (-limit..limit).each do |i|
+      x0 = x_coord + i
+      y0 = y_coord
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+      x0 = x_coord
+      y0 = y_coord + i
+      moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)
+    end
+    moves_array
+  end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -15,6 +15,7 @@ class Rook < Piece
     limit = 7
     moves_array = []
     (-limit..limit).each do |i|
+      # rubocop:disable NumericPredicate
       x0 = x_coord + i
       y0 = y_coord
       moves_array << [x0, y0] unless (x0 == x_coord && y0 == y_coord) || (x0 > 7 || y0 > 7 || x0 < 0 || y0 < 0)

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -84,7 +84,7 @@
     selectedPieceXCoord = $(piece).parent().attr("data-x-coord");
     selectedPieceYCoord = $(piece).parent().attr("data-y-coord");
   // make selected piece draggable
-    $(piece).draggable({ containment: ".board-container", grid: [50,50], revert: 'invalid'});
+    $(piece).draggable({ containment: ".board", grid: [50,50], revert: 'invalid', stack: piece});
     
   // set class of piece to selected
     $(".piece").removeClass("selected");
@@ -96,7 +96,7 @@
   // droppable
     $( ".square" ).droppable({
       accept: piece,
-      drop: function( event, ui ) {
+      drop: function( event ) {
         square = event.target;
         
         selectedSquareXCoord = $(square).attr("data-x-coord");

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,8 +1,14 @@
 <section class="board-container">
 <% if @game.check?(@game.player_color(@current_player)) %>
-  <div class="alert alert-danger">
-      <strong>Check</strong> <%=@game.player_color(@current_player)%> is in check by <%=@game.checking_piece%>
-  </div>
+  <% if @game.checkmate?(@game.player_color(@current_player)) %>
+    <div class="alert alert-danger">
+        <strong>Checkmate</strong> <%=@game.player_color(@current_player)%> loses!
+    </div>
+  <% else %>
+    <div class="alert alert-danger">
+        <strong>Check</strong> <%=@game.current_turn%> is in check by <%=@game.show_checking_piece%>
+    </div>
+  <% end %>
 <% end %>
   <div class="board" data-game-id="<%= @game.id %>">
     <% if @current_player.id == @game.white_player_id %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,6 +9,10 @@
         <strong>Check</strong> <%=@game.current_turn%> is in check by <%=@game.show_checking_piece%>
     </div>
   <% end %>
+<% elsif @game.stalemate?(@game.player_color(@current_player)) %>
+  <div class="alert alert-danger">
+    <strong>Stalemate</strong> Game is a draw.
+  </div>
 <% end %>
   <div class="board" data-game-id="<%= @game.id %>">
     <% if @current_player.id == @game.white_player_id %>


### PR DESCRIPTION
### What does this PR do?
CSS changes, draggable fixes, and some logic fixes
1. Disabled board:hover. Board no longer shifts on mouseover
2. Draggable piece had an issue where the first column is out of reach when .board is used as the containment. This is fixed by specifying a zero margin for .row.
3. Draggable piece would disappear behind the bottom row squares. Fixed by adding stack parameter to draggable.
4. Added checkmate and stalemate call in show.html.erb
5. Fixed move_out_of_check in king.rb, fix block_check in piece.rb
6. Added ActiveRecord rollback to ensure that next move does not result in check. Note that "reload" had to be added for the updated attributes to save properly.
7. Moved pos_filled_with_same_color into valid_move condition. Results in a stalemate to fail - the result is correct, need to debug stalemate.
8. Fixed stalemate by adding a condition that checks if any legal moves by remaining pieces are available without going into check. This required adding correct_moves methods to each piece role, which returns an array of possible coordinates for a specified piece. 

### How do I manually test this?
Pull, rails s, start a game. Choose a piece to drag, and drag all over the board - the piece should not disappear and should not go beyond the board perimeter.

rspec